### PR TITLE
Update availability.md - call out in-process function app model

### DIFF
--- a/articles/azure-monitor/app/availability.md
+++ b/articles/azure-monitor/app/availability.md
@@ -94,7 +94,7 @@ This example is designed only to show you the mechanics of how the `TrackAvailab
 ### Get started
 
 > [!NOTE]
-> To follow these instructions, you must use either the [App Service](/azure/azure-functions/dedicated-plan) plan or Functions Premium plan to allow editing code in App Service Editor.
+> To follow these instructions, you must use either the [App Service](/azure/azure-functions/dedicated-plan) plan or Functions Premium plan to allow editing code in App Service Editor. You also must choose a runtime version that supports the in-process model.
 > 
 > If you're testing behind a virtual network or testing nonpublic endpoints, you'll need to use the Functions Premium plan.
 


### PR DESCRIPTION
Fix to the following issue:

While going through our "Custom Availability Test" / TrackAvailability doc (https://learn.microsoft.com/en-us/azure/azure-monitor/app/availability-azure-functions#basic-code-sample), I noticed that the instructions are missing one key element now: Editing the Function App directly in portal only works with "in-process" .NET 6 Functions, not with "isolated process" .NET 8 which is the new default. So customers have to make an additional selection that's different from the defaults when creating the app, or the instructions in doc don't work